### PR TITLE
fix(reuse): annotate l10n translation files

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -41,3 +41,12 @@ path = [
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 LibreCode coop and LibreCode contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
+path = [
+  "l10n/*.js",
+  "l10n/*.json",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 LibreCode coop and LibreCode contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- add REUSE annotations for l10n translation artifacts
- cover l10n/*.js and l10n/*.json with AGPL-3.0-or-later metadata

## Validation
- reuse lint