### PR TITLE
fix(deps): restore typescript 5.x peer compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@vue/test-utils": "^2.4.6",
         "jsdom": "^29.0.1",
         "openapi-typescript": "^7.13.0",
-        "typescript": "^6.0.2",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.1"
       },
       "engines": {
@@ -8755,9 +8755,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
     "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
-    "@vue/test-utils": "^2.4.6",
-    "@vitejs/plugin-vue": "^6.0.5",
     "@nextcloud/browserslist-config": "^3.1.2",
     "@nextcloud/vite-config": "^2.5.2",
     "@playwright/test": "^1.54.2",
+    "@vitejs/plugin-vue": "^6.0.5",
+    "@vue/test-utils": "^2.4.6",
     "jsdom": "^29.0.1",
     "openapi-typescript": "^7.13.0",
-    "typescript": "^6.0.2",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- restore TypeScript to 
- keep compatibility with  peer requirement ()
- unblock 
added 667 packages, and audited 668 packages in 7s

212 packages are looking for funding
  run `npm fund` for details

9 vulnerabilities (7 low, 2 moderate)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details. in Node/OpenAPI/Playwright workflows

## Validation
- npm run ts:check
- npm run test