### PR TITLE
fix(actions): align appstore push inputs with LibreSign

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -136,13 +136,9 @@ jobs:
           overwrite: true
 
       - name: Upload app to Nextcloud appstore
-        env:
-          APPSTORE_TOKEN: ${{ secrets.APPSTORE_TOKEN }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-        if: env.APPSTORE_TOKEN != '' && env.APP_PRIVATE_KEY != ''
         uses: nextcloud-releases/nextcloud-appstore-push-action@a011fe619bcf6e77ddebc96f9908e1af4071b9c1 # v1.0.3
         with:
           app_name: ${{ env.APP_NAME }}
-          appstore_token: ${{ env.APPSTORE_TOKEN }}
+          appstore_token: ${{ secrets.APPSTORE_TOKEN }}
           download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
-          app_private_key: ${{ env.APP_PRIVATE_KEY }}
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -230,14 +230,10 @@ jobs:
           overwrite: true
 
       - name: Upload app to Nextcloud appstore (nightly)
-        env:
-          APPSTORE_TOKEN: ${{ secrets.APPSTORE_TOKEN }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-        if: env.APPSTORE_TOKEN != '' && env.APP_PRIVATE_KEY != ''
         uses: nextcloud-releases/nextcloud-appstore-push-action@a011fe619bcf6e77ddebc96f9908e1af4071b9c1 # v1.0.3
         with:
           app_name: ${{ env.APP_NAME }}
-          appstore_token: ${{ env.APPSTORE_TOKEN }}
+          appstore_token: ${{ secrets.APPSTORE_TOKEN }}
           download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
-          app_private_key: ${{ env.APP_PRIVATE_KEY }}
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           nightly: true


### PR DESCRIPTION
## Summary
- pass APPSTORE_TOKEN and APP_PRIVATE_KEY directly in the appstore push action inputs
- remove env indirection from release and nightly workflows
- keep the signing/build flow already aligned with LibreSign

## Why
The release workflow now builds and signs successfully, but the App Store upload still fails with HTTP 400. This change matches LibreSign wiring exactly for the upload action, especially for multiline private key handling.