### PR TITLE
fix(migration): support false on active boolean column

### DIFF
--- a/lib/Migration/Version1000Date20260309120000.php
+++ b/lib/Migration/Version1000Date20260309120000.php
@@ -54,6 +54,7 @@ class Version1000Date20260309120000 extends SimpleMigrationStep {
 				'unsigned' => true,
 			]);
 			$table->addColumn('active', Types::BOOLEAN, [
+				'notnull' => false,
 				'default' => true,
 			]);
 			$table->addColumn('options', Types::TEXT, [

--- a/lib/Migration/Version1001Date20260404010000.php
+++ b/lib/Migration/Version1001Date20260404010000.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and LibreCode contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\ProfileFields\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1001Date20260404010000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('profile_fields_definitions')) {
+			return null;
+		}
+
+		$table = $schema->getTable('profile_fields_definitions');
+		if (!$table->hasColumn('active')) {
+			return null;
+		}
+
+		$activeColumn = $table->getColumn('active');
+		if (!$activeColumn->getNotnull()) {
+			return null;
+		}
+
+		$table->changeColumn('active', [
+			'notnull' => false,
+			'default' => true,
+		]);
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
## Summary
- make active nullable in migration Version1000Date20260309120000 to avoid DB compatibility rejection when persisting false
- add migration Version1001Date20260404010000 to adjust existing installs where active was created as not-null

## Validation
- docker compose exec -u www-data -w /var/www/html/apps-extra/profile_fields nextcloud composer cs:fix
- docker compose exec -u www-data -w /var/www/html/apps-extra/profile_fields nextcloud composer psalm
- docker compose exec -u www-data -w /var/www/html/apps-extra/profile_fields nextcloud composer test:unit
- docker compose exec -u www-data -w /var/www/html/apps-extra/profile_fields nextcloud composer test:php:controller-integration
- docker compose exec -u www-data -w /var/www/html/apps-extra/profile_fields nextcloud composer test:php (fails in API suite with 503 Service unavailable, environment-related)

Closes #58