### PR TITLE
fix(migration): shorten index name for DB compatibility

### DIFF
--- a/lib/Migration/Version1000Date20260309120000.php
+++ b/lib/Migration/Version1000Date20260309120000.php
@@ -65,7 +65,7 @@ class Version1000Date20260309120000 extends SimpleMigrationStep {
 
 			$table->setPrimaryKey(['id']);
 			$table->addUniqueIndex(['field_key'], 'profile_fields_def_key_uk');
-			$table->addIndex(['active', 'sort_order'], 'profile_fields_def_active_order_idx');
+			$table->addIndex(['active', 'sort_order'], 'pf_def_active_sort_idx');
 		}
 
 		if (!$schema->hasTable('profile_fields_values')) {


### PR DESCRIPTION
## Summary
- shorten the index identifier for (active, sort_order) in migration Version1000Date20260309120000
- prevents installation failure on DB engines with stricter identifier length limits

## Validation
- docker compose exec -u www-data -w /var/www/html/apps-extra/profile_fields nextcloud composer cs:fix
- docker compose exec -u www-data -w /var/www/html/apps-extra/profile_fields nextcloud composer psalm
- docker compose exec -u www-data -w /var/www/html/apps-extra/profile_fields nextcloud composer test:unit
- docker compose exec -u www-data -w /var/www/html/apps-extra/profile_fields nextcloud composer test:php:controller-integration

Closes #65