### PR TITLE
chore(release): prepare v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 <!-- changelog-linker -->
 ## [Unreleased]
 
+## 1.0.2 - 2026-04-13
+
+💝 **SUPPORT PROFILE FIELDS** — If this project helps your team, please support ongoing maintenance via GitHub Sponsors: https://github.com/sponsors/LibreSign
+
+⭐ **STAR THE REPOSITORY** — Stars help the project gain visibility and justify continued investment: https://github.com/LibreCodeCoop/profile_fields
+
+🏢 **ENTERPRISE SUPPORT** — Need custom development, support, or sponsored features? Contact us: contact@librecode.coop
+
+### Fixed
+- Fixed migration compatibility for `profile_fields_definitions.active` and ensured upgrade safety for existing installs [#73](https://github.com/LibreCodeCoop/profile_fields/pull/73)
+- Fixed migration failure on strict database identifier limits by shortening an index name [#74](https://github.com/LibreCodeCoop/profile_fields/pull/74)
+
+### Changed
+- Updated project dependencies and CI tooling via Dependabot updates [#64](https://github.com/LibreCodeCoop/profile_fields/pull/64) [#66](https://github.com/LibreCodeCoop/profile_fields/pull/66) [#69](https://github.com/LibreCodeCoop/profile_fields/pull/69) [#70](https://github.com/LibreCodeCoop/profile_fields/pull/70) [#71](https://github.com/LibreCodeCoop/profile_fields/pull/71) [#72](https://github.com/LibreCodeCoop/profile_fields/pull/72)
+
 ## 1.0.1 - 2026-04-03
 
 💝 **SUPPORT PROFILE FIELDS** — If this project helps your team, please support ongoing maintenance via GitHub Sponsors: https://github.com/sponsors/LibreSign
@@ -40,5 +55,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `occ` commands for data export, import, clear, and developer reset [#5](https://github.com/LibreCodeCoop/profile_fields/pull/5)
 - Transifex integration for community translations [#34](https://github.com/LibreCodeCoop/profile_fields/pull/34)
 
-[Unreleased]: https://github.com/LibreCodeCoop/profile_fields/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/LibreCodeCoop/profile_fields/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/LibreCodeCoop/profile_fields/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/LibreCodeCoop/profile_fields/compare/v1.0.0...v1.0.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@ Developed with ❤️ by [LibreCode](https://librecode.coop). Ongoing maintenanc
 
 * [Sponsor LibreSign on GitHub (monthly recurring support is especially welcome): ![Donate using GitHub Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/LibreSign)
 	]]></description>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<licence>agpl</licence>
 	<author mail="contact@librecode.coop" homepage="https://librecode.coop">LibreCode</author>
 	<namespace>ProfileFields</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "profile_fields",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "profile_fields",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "profile_fields",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Profile fields",
   "license": "AGPL-3.0-or-later",
   "private": true,


### PR DESCRIPTION
## Summary
- prepare changelog for 1.0.2
- bump app metadata version to 1.0.2
- bump package metadata and lockfile version to 1.0.2

## Validation
- npm run ts:check
- npm run test

## Next release step
- after merge, create and push tag v1.0.2 to trigger release pipeline
